### PR TITLE
Remove alocação de buffer para stdout/stderr

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -10,16 +10,14 @@ import (
 )
 
 func copyAndCapture(w io.Writer, r io.Reader) ([]byte, error) {
-	var out []byte
 	buf := make([]byte, 1024, 1024)
 	for {
 		n, err := r.Read(buf[:])
 		if n > 0 {
 			d := buf[:n]
-			out = append(out, d...)
 			_, err := w.Write(d)
 			if err != nil {
-				return out, err
+				return d, err
 			}
 		}
 		if err != nil {
@@ -27,7 +25,7 @@ func copyAndCapture(w io.Writer, r io.Reader) ([]byte, error) {
 			if err == io.EOF {
 				err = nil
 			}
-			return out, err
+			return make([]byte, 0), err
 		}
 	}
 	// never reached


### PR DESCRIPTION
***Para o futuro , devemos atualizar o env-aws-params para a versão mais atual, que possui varias melhorias no gerenciamento do processo (sinais e stdout/stderr): https://github.com/gmr/env-aws-params***


Para comandos que rodam por muito tempo e geram muita saída no
stdout/stderr (exemplo, os BFFs), o buffer cresce centenas de MB até
estourar o limite de 1.5G dos containers.

A alteração faz com que a saída seja apenas escrita no
os.Stdout/os.Stderr e não acumulada em buffer.

Apenas no caso (incomum) de erro de escrita no stdout/stderr será
retornado o conteúdo que tentou-se escrever.

Em caso de EOF, não será retornada a saída, visto que ela já foi escrita
com sucesso anteriormente.

## Comportamento de consumo de RAM

Ajustei o build da imagem dev do `bff-integration` para usar o `env-aws-params`, com um ajuste para não chamar a API do SSM [com esse patch](https://gist.github.com/lizardo/630972c72324c1276e2f6ce43941196e).

O teste consistiu em rodar [esse script](https://gist.github.com/lizardo/184266776f03f27cbc4be1ab0133c15b), que faz um loop de chamadas ao BFF. Com a versão corrigida, o consumo de RAM ficou assim após aprox. 1 hora:

![screenshot from 2019-01-10 11-54-19](https://user-images.githubusercontent.com/383724/50986225-9b289700-14dc-11e9-9065-5d6e06ba5eaf.png)

Ou seja, consumo estável em 100MB, apenas o cache subindo (normal).

Com a versão original, o comportamento era assim, apóx **15 min**:

![screenshot from 2019-01-10 13-38-06](https://user-images.githubusercontent.com/383724/50986379-112cfe00-14dd-11e9-9e9d-efc72d5a73b4.png)

Ou seja, já havia passado de 200MB , sem cache.

Rodando `docker exec -it meliuz_bff_integration ps --width 200 -auxf` deu pra constatar  o RSS do processo `env-aws-params` em 146MB.

## Cenários de Teste

Para os testes, eu apliquei esse diff para evitar o uso do SSM (alternativamente, pode-se configurar chaves e passar valores validos para o SSM funcionar):

```diff
diff --git a/main.go b/main.go
index 17d556f..fe578bb 100644
--- a/main.go
+++ b/main.go
@@ -93,7 +93,7 @@ func errorPrefix(err error) string {
 
 func getParameters(c *cli.Context) (map[string]string, error) {
        values := make(map[string]string)
-
+/*
        client, err := NewSSMClient(c.GlobalString("aws-region"))
        if err != nil {
                return values, err
@@ -108,6 +108,7 @@ func getParameters(c *cli.Context) (map[string]string, error) {
                        values[k] = v
                }
        }
+*/
        return values, nil
 }
 
```

### Teste 1 (saída com EOF)

```
docker-compose run --rm env-aws-params ./env-aws-params --prefix /bff-integration/production/base --prefix /bff-integration/production/bff --aws-region sa-east-1 --sanitize --upcase cat /etc/passwd
```

Deve ser exibido a saída apenas uma vez.


### Teste 2 (termino por sinal SIGTERM)

```
docker-compose run --rm env-aws-params ./env-aws-params --prefix /bff-integration/production/base --prefix /bff-integration/production/bff --aws-region sa-east-1 --sanitize --upcase bash -c 'echo some output; kill $$'
```

Deve ser exibido o erro por "Terminated" e é exibido a mensagem `some output` apenas uma vez.