### PR TITLE
Ajusta build da imagem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,10 @@ RUN apt-get update && apt-get install -y unzip --no-install-recommends && \
     echo '31144e465e52ffbc0035248a10ddea61a09bf28b00784fd3fdd9882c8cbb2315  dep' | sha256sum -c - && \
     chmod +x dep && mv dep /usr/local/bin
 
-RUN mkdir -p /go/src/github.com/${APPLICATION_NAME}
 WORKDIR /go/src/github.com/${APPLICATION_NAME}
 
 COPY Gopkg.toml Gopkg.lock ./
-
 RUN dep ensure -vendor-only
+
+COPY . .
+RUN go build

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,11 @@ all: build
 
 build:
 	@docker-compose build --pull
-	@docker-compose run --rm ${APPLICATION_NAME} go build
+	@docker run -v $$PWD:/src --rm ${APPLICATION_NAME}:latest cp ${APPLICATION_NAME} /src
 
 build-no-cache:
 	@docker-compose build --no-cache --pull
-	@docker-compose run --rm ${APPLICATION_NAME} go build
+	@docker run -v $$PWD:/src --rm ${APPLICATION_NAME}:latest cp ${APPLICATION_NAME} /src
 
 down:
 	@docker-compose down


### PR DESCRIPTION
Faz o "go build" no Dockerfile, garantindo que a imagem gerada contém o
executável, ao invés de depender deste estar no diretório corrente.

Isso permite usar testar o executável em ambiente de CI com Docker In
Docker mais facilmente, além de podermos usar a imagem para distribuir o
executável mais facilmente no futuro.