### PR TITLE
fix: Corrige build da imagem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   docker-builder:
     docker:
-      - image: meliuz/docker-builder:latest
+      - image: meliuz/docker-builder:1.0.0
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -15,16 +15,10 @@ commands:
           name: Log into Docker Hub
           command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
 
-  load-env:
-    steps:
-      - run:
-          name: Load environment variables
-          command: echo "export $(grep -v '^#' .env | tr '\r\n' ' ')" >> ${BASH_ENV}
-
 jobs:
   lint:
     docker:
-      - image: meliuz/docker-linter:latest
+      - image: meliuz/docker-linter:1.2.0
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -47,11 +41,13 @@ jobs:
       - checkout
       - setup_remote_docker
       - docker-login
-      - load-env
 
       - run:
           name: Build image
-          command: build-image meliuz/${CIRCLE_PROJECT_REPONAME}:testing . APPLICATION_NAME
+          command: |
+            export APPLICATION_NAME=${CIRCLE_PROJECT_REPONAME}
+
+            build-image meliuz/${CIRCLE_PROJECT_REPONAME}:testing . APPLICATION_NAME
 
       - run:
           name: Save image

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ FROM scratch
 ARG APPLICATION_NAME
 
 WORKDIR /app
-COPY --from=builder /go/src/github.com/${APPLICATION_NAME} .
+COPY --from=builder /go/src/github.com/${APPLICATION_NAME}/${APPLICATION_NAME} .


### PR DESCRIPTION
- Corrige caminho incorreto no COPY
- Corrige definição da variável APPLICATION_NAME
- Fixa versões das imagens usadas no CI

# Instruções para teste (usando CircleCI CLI)

1) Colocar o usuario e senha do docker hub em variáveis:

```
export DOCKER_USER=...
export DOCKER_PASS=...
```

2) Fazer pull da imagem `meliuz/docker-builder` manualmente (necessário se vc tiver erros durante o pull das imagens no `circleci local execute` abaixo):

```
docker pull meliuz/docker-builder:1.0.0
```

3) Fazer o build da imagem localmente (testa o job "build" do CI; o `circleci config process` é necessário pois o circleci CLI não suporta o formato 2.1 ainda, e esse comando "converte" para 2.0):

```
circleci config process .circleci/config.yml > .circleci/config-tmp.yml
circleci local execute --job build -c .circleci/config-tmp.yml -e DOCKER_USER=$DOCKER_USER -e DOCKER_PASS=$DOCKER_PASS -e CIRCLE_PROJECT_REPONAME=env-aws-params
```

## Comportamento esperado

1) Imagem gerada tem tamanho de aprox. 14MB:

```
$ docker images meliuz/env-aws-params:testing
REPOSITORY              TAG                 IMAGE ID            CREATED             SIZE
meliuz/env-aws-params   testing             33e04aa2cfaa        About an hour ago   13.9MB
```

2) Imagem contém binário funcional:

```
$ (t=$(docker create meliuz/env-aws-params:testing /xxx); docker export $t | tar -C /tmp -xf- app/env-aws-params; /tmp/app/env-aws-params --help; docker rm $t; rm /tmp/app/env-aws-params; rmdir /tmp/app)
NAME:
   env-aws-params - Application entry-point that injects SSM Parameter Store values as Environment Variables

USAGE:
   env-aws-params [global options] -p prefix command [command arguments]

VERSION:
   0.0.0

COMMANDS:
     help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --aws-region value        The AWS region to use for the Parameter Store API [$AWS_REGION]
   --prefix value, -p value  Key prefix that is used to retrieve the environment variables - supports multiple use
   --pristine                Only use values retrieved from Parameter Store, do not inherit the existing environment variables
   --basename                Only use basename of variable path
   --sanitize                Replace invalid characters in keys to underscores
   --strip                   Strip invalid characters in keys
   --upcase                  Force keys to uppercase
   --help, -h                show help
   --version, -v             print the version
b871e5dfce77aff8fd3a4bdd6f28bf2371bd71a23253050cf941a2704e2dc3a6
```